### PR TITLE
pathlib.Path cast of path supplied to bokeh

### DIFF
--- a/hulearn/experimental/interactive.py
+++ b/hulearn/experimental/interactive.py
@@ -181,7 +181,7 @@ class SingleInteractiveChart:
             self.poly_patches[k] = self.plot.patches(
                 [], [], fill_color=col, fill_alpha=0.4, line_alpha=0.0
             )
-            icon_path = resource_filename("hulearn", f"images/{col}.png")
+            icon_path = pathlib.Path(resource_filename("hulearn", f"images/{col}.png"))
             self.poly_draw[k] = PolyDrawTool(
                 renderers=[self.poly_patches[k]], custom_icon=icon_path
             )


### PR DESCRIPTION
When using from **hulearn.experimental.interactive.InteractiveCharts**, we encounter the following warning: _BokehDeprecationWarning: raw string path was deprecated in Bokeh 2.4.0 and will be removed, use pathlib.Path instead_.. 

I've added a simple cast to pathlib.Path in **line 184** in **hulearn/experimental/interactive.py** which resolves this and makes sure **SingleInteractiveChart** won't fail with Bokeh 2.4.0.